### PR TITLE
Multi server support

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -23,7 +23,6 @@ struct Args {
     uint32_t num_samples = 10;
     uint32_t mean_inter_packet_delay = 200;
     uint8_t timeout = 10;
-    uint8_t max_retries = 10;
     uint32_t seed = 0;
     char sep = ',';
     bool sync_time = true;

--- a/include/Client.h
+++ b/include/Client.h
@@ -13,6 +13,7 @@ extern "C" {
 #include "simple-qoo.h"
 }
 struct Args {
+    std::vector<std::string> remote_hosts;
     std::string remote_host;
     std::string remote_port = "443";
     std::string local_host;
@@ -55,7 +56,7 @@ public:
 private:
     int fd = -1;
     bool header_printed = false;
-    struct addrinfo* remote_address_info={};
+    std::vector<struct addrinfo*> remote_address_info={};
     struct addrinfo* local_address_info= {};
     struct sqa_stats* stats_RTT = sqa_stats_create();
     struct sqa_stats* stats_internal = sqa_stats_create();

--- a/include/Client.h
+++ b/include/Client.h
@@ -14,8 +14,7 @@ extern "C" {
 }
 struct Args {
     std::vector<std::string> remote_hosts;
-    std::string remote_host;
-    std::string remote_port = "443";
+    std::vector<uint16_t> remote_ports;
     std::string local_host;
     std::string local_port = "445";
     std::vector<uint16_t> payload_lens = std::vector<uint16_t>();

--- a/include/Client.h
+++ b/include/Client.h
@@ -22,7 +22,7 @@ struct Args {
     uint8_t dscp_snd = 0;
     uint32_t num_samples = 10;
     uint32_t mean_inter_packet_delay = 200;
-    uint8_t timeout = 10;
+    uint8_t timeout = 100;
     uint32_t seed = 0;
     char sep = ',';
     bool sync_time = true;
@@ -60,6 +60,8 @@ private:
     struct sqa_stats* stats_internal = sqa_stats_create();
     struct sqa_stats* stats_client_server = sqa_stats_create();
     struct sqa_stats* stats_server_client = sqa_stats_create();
+    time_t first_packet_sent = 0;
+    time_t last_packet_sent = 0;
     Args args;
     TimeSynchronizer* timeSynchronizer = new TimeSynchronizer();
     ClientPacket craftSenderPacket(uint32_t idx);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -25,7 +25,15 @@ Client::Client(const Args& args) {
     remote_address_info.resize(args.remote_hosts.size());
     int i = 0;
     for (const auto& remote_host : args.remote_hosts) {
-        int err=getaddrinfo(remote_host.c_str(), args.remote_port.c_str(), &hints, &remote_address_info[i]);
+        const char* port = nullptr;
+        try {
+            // Convert port number to string
+            port = const_cast<char*>(std::to_string(args.remote_ports.at(i)).c_str());
+        } catch (std::out_of_range& e) {
+            std::cerr << "Not enough remote ports provided" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        int err=getaddrinfo(remote_host.c_str(), port, &hints, &remote_address_info[i]);
         if (err!=0) {
             std::cerr << "failed to resolve remote socket address: " << err;
             std::exit(EXIT_FAILURE);

--- a/src/client/main_client.cpp
+++ b/src/client/main_client.cpp
@@ -22,10 +22,10 @@ Args parse_args(int argc, char **argv){
     uint8_t dscp = 0, tos = 0;
     CLI::App app{"Twamp-Light implementation written by Domos."};
     app.option_defaults()->always_capture_default(true);
-    app.add_option("addresses", args.remote_hosts, "The address of the remote TWAMP Server.");
+    app.add_option("addresses", args.remote_hosts, "The address of the remote TWAMP Server.")->required();
     app.add_option("-a, --local_address", args.local_host, "The address to set up the local socket on. Auto-selects by default.");
     app.add_option("-P, --local_port", args.local_port, "The port to set up the local socket on.");
-    app.add_option("-p, --port", args.remote_port, "The port that the remote server is listening on.");
+    app.add_option<std::vector<uint16_t>>("-p, --port", args.remote_ports, "The port that the remote server is listening on.")->default_str(vectorToString(args.remote_ports, " "))->check(CLI::Range(0, 65535));
     app.add_option<std::vector<uint16_t>>("-l, --payload_lens", args.payload_lens,
             "The payload length. Must be in range (42, 1473). Can be multiple values, in which case it will be sampled randomly.")
             ->default_str(vectorToString(args.payload_lens, " "))->check(CLI::Range(42, 1473));

--- a/src/client/main_client.cpp
+++ b/src/client/main_client.cpp
@@ -22,7 +22,7 @@ Args parse_args(int argc, char **argv){
     uint8_t dscp = 0, tos = 0;
     CLI::App app{"Twamp-Light implementation written by Domos."};
     app.option_defaults()->always_capture_default(true);
-    app.add_option("address", args.remote_host, "The address of the remote TWAMP Server.");
+    app.add_option("addresses", args.remote_hosts, "The address of the remote TWAMP Server.");
     app.add_option("-a, --local_address", args.local_host, "The address to set up the local socket on. Auto-selects by default.");
     app.add_option("-P, --local_port", args.local_port, "The port to set up the local socket on.");
     app.add_option("-p, --port", args.remote_port, "The port that the remote server is listening on.");
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
         //Parent does the packet collecting
         time_t time_of_last_received_packet = time(NULL);
         close(pipefd[1]); // close the write-end of the pipe
-        while (time(NULL) - time_of_last_received_packet < args.timeout && index < args.num_samples)
+        while (time(NULL) - time_of_last_received_packet < args.timeout && index < args.num_samples * args.remote_hosts.size())
         {
             bool response = client.awaitResponse(lost_packets);
             if (response){

--- a/src/server/main_server.cpp
+++ b/src/server/main_server.cpp
@@ -15,13 +15,15 @@ Args parse_args(int argc, char **argv){
     app.add_option("--sep", args.sep, "The separator to use in the output.");
     app.add_flag("--no-sync{false}", args.sync_time, "Disables time synchronization mechanism. Not RFC-compatible, so disable to make this work with other TWAMP implementations.");
     auto opt_tos = app.add_option("-T, --tos", tos, "The TOS value (<256).")->check(CLI::Range(256))->default_str(std::to_string(args.snd_tos));
-
-    try{
+    try {
         app.parse(argc, argv);
-    }catch(const CLI::ParseError &e) {
+    } catch(const CLI::ParseError &e) {
         std::exit((app).exit(e));
     }
 
+    if(*opt_tos){
+        args.snd_tos = tos - (((tos & 0x2) >> 1) & (tos & 0x1));
+    }
     return args;
 }
 


### PR DESCRIPTION
Adds support for measuring towards multiple servers from a single client instance.

Example use:

twamp-light-client -p 4001 4002 192.168.1.1 10.100.1.1