### PR TITLE
client: add option to print lost and sent packet counters

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -33,6 +33,7 @@ struct Args {
     bool sync_time = false;
     bool print_digest = false;
     bool print_RTT_only = false;
+    bool print_lost_packets = false;
     std::string print_format = "legacy";
     std::string json_output_file;
 };
@@ -72,8 +73,9 @@ struct MetricData {
     int64_t server_client_delay = 0;
     int64_t internal_delay = 0;
     int64_t rtt_delay = 0;
-    uint16_t packet_loss = 0;
     uint64_t initial_send_time = 0;
+    uint64_t packets_sent = 0;
+    uint64_t packets_lost = 0;
     ReflectorPacket packet;
     IPHeader ipHeader;
 };
@@ -132,7 +134,8 @@ class Client {
     void printReflectorPacket(ReflectorPacket *reflectorPacket,
                               msghdr msghdr,
                               ssize_t payload_len,
-                              uint64_t incoming_timestamp_nanoseconds);
+                              uint64_t incoming_timestamp_nanoseconds,
+                              struct sqa_stats *stats);
 
     template <typename Func> void printSummaryLine(const std::string &label, Func func);
 

--- a/src/client/main_client.cpp
+++ b/src/client/main_client.cpp
@@ -34,6 +34,7 @@ Args parse_args(int argc, char **argv)
     app.add_option("-s, --seed", args.seed, "Seed for the RNG. 0 means random.");
     app.add_flag("--print-digest{true}", args.print_digest, "Prints a statistical summary at the end.");
     app.add_option("-j, --json-output", args.json_output_file, "Filename to dump json output to");
+    app.add_flag("--print-lost-packets", args.print_lost_packets, "Prints sent and lost packet counters, legacy format only");
     app.add_option("--print-RTT-only", args.print_RTT_only, "Prints only the RTT values.");
     app.add_option("--print-format",
                    args.print_format,
@@ -110,7 +111,7 @@ int main(int argc, char **argv)
     std::thread receiver_thread(&Client::runReceiverThread, &client);
     std::thread sender_thread(&Client::runSenderThread, &client);
     client.printHeader();
-    if (args.print_format != "legacy") {
+    if (args.print_format != "legacy" || args.print_lost_packets) {
         client.runCollatorThread();
     }
     sender_thread.join();


### PR DESCRIPTION
Previously existing "LOSS" field in legacy output was broken, this also fixes that.